### PR TITLE
Lock uuid version to 3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "object.entries": "^1.0.4",
     "object.values": "^1.0.4",
     "prop-types": "^15.5.10",
-    "uuid": "^3.0.1"
+    "uuid": "3.0.1"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
Testing this out in attempt to fix https://github.com/airbnb/enzyme/issues/1020